### PR TITLE
doctest upgrade

### DIFF
--- a/paland.cc
+++ b/paland.cc
@@ -36,6 +36,11 @@
 #include <iostream>
 #include <sstream>
 
+#ifdef _MSC_VER
+  #pragma warning(disable:4464) // relative include uses ..
+  #pragma warning(disable:4514) // unreferenced inline function removed
+#endif
+
 // The configuration flags are injected by CMakeLists.txt in the npf project.
 #define NANOPRINTF_IMPLEMENTATION
 #include "../../nanoprintf.h"
@@ -47,10 +52,6 @@
       #pragma GCC diagnostic ignored "-Wreserved-identifier"
     #endif
   #endif
-#endif
-
-#ifdef _MSC_VER
-  #pragma warning(disable:4514) // unreferenced inline function removed
 #endif
 
 #include "../doctest.h"

--- a/paland.cc
+++ b/paland.cc
@@ -39,6 +39,7 @@
 #ifdef _MSC_VER
   #pragma warning(disable:4464) // relative include uses ..
   #pragma warning(disable:4514) // unreferenced inline function removed
+  #pragma warning(disable:4820) // padding after data member
 #endif
 
 // The configuration flags are injected by CMakeLists.txt in the npf project.

--- a/paland.cc
+++ b/paland.cc
@@ -44,13 +44,15 @@
 
 #if NANOPRINTF_HAVE_GCC_WARNING_PRAGMAS
   #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wc++98-compat-pedantic"
+  #if NANOPRINTF_CLANG
+    #pragma GCC diagnostic ignored "-Wc++98-compat-pedantic"
+    #pragma GCC diagnostic ignored "-Wformat-pedantic"
+  #endif
   #pragma GCC diagnostic ignored "-Wold-style-cast"
   #pragma GCC diagnostic ignored "-Wpadded"
   #pragma GCC diagnostic ignored "-Wformat"
   #pragma GCC diagnostic ignored "-Wformat-nonliteral"
   #pragma GCC diagnostic ignored "-Wformat-security"
-  #pragma GCC diagnostic ignored "-Wformat-pedantic"
 #endif
 
 namespace {

--- a/paland.cc
+++ b/paland.cc
@@ -29,18 +29,20 @@
 // Rewritten for nanoprintf by Charles Nicholson (charles.nicholson@gmail.com)
 // A derivative work of Paland's original, so released under the MIT License.
 
+#ifdef _MSC_VER
+  #pragma warning(disable:4464) // relative include uses ..
+  #pragma warning(disable:4514) // unreferenced inline function removed
+  #pragma warning(disable:4820) // padding after data member
+  #pragma warning(disable:4710) // function not inlined
+  #pragma warning(disable:4711) // selected for inline
+#endif
+
 #include <string.h>
 #include <math.h>
 #include <limits>
 #include <string>
 #include <iostream>
 #include <sstream>
-
-#ifdef _MSC_VER
-  #pragma warning(disable:4464) // relative include uses ..
-  #pragma warning(disable:4514) // unreferenced inline function removed
-  #pragma warning(disable:4820) // padding after data member
-#endif
 
 // The configuration flags are injected by CMakeLists.txt in the npf project.
 #define NANOPRINTF_IMPLEMENTATION

--- a/paland.cc
+++ b/paland.cc
@@ -47,6 +47,7 @@
   #if NANOPRINTF_CLANG
     #pragma GCC diagnostic ignored "-Wc++98-compat-pedantic"
     #pragma GCC diagnostic ignored "-Wformat-pedantic"
+    #pragma GCC diagnostic ignored "-Wreserved-identifier"
   #endif
   #pragma GCC diagnostic ignored "-Wold-style-cast"
   #pragma GCC diagnostic ignored "-Wpadded"

--- a/paland.cc
+++ b/paland.cc
@@ -41,7 +41,6 @@
 #include "../../nanoprintf.h"
 
 #if NANOPRINTF_HAVE_GCC_WARNING_PRAGMAS
-  #pragma GCC diagnostic push
   #if NANOPRINTF_CLANG
     #pragma GCC diagnostic ignored "-Wc++98-compat-pedantic"
     #ifndef __APPLE__
@@ -50,10 +49,13 @@
   #endif
 #endif
 
+#ifdef _MSC_VER
+  #pragma warning(disable:4514) // unreferenced inline function removed
+#endif
+
 #include "../doctest.h"
 
 #if NANOPRINTF_HAVE_GCC_WARNING_PRAGMAS
-  #pragma GCC diagnostic push
   #if NANOPRINTF_CLANG
     #pragma GCC diagnostic ignored "-Wformat-pedantic"
   #endif

--- a/paland.cc
+++ b/paland.cc
@@ -42,7 +42,7 @@
 #define NANOPRINTF_IMPLEMENTATION
 #include "../../nanoprintf.h"
 
-#if NANOPRINTF_CLANG_OR_GCC_PAST_4_6
+#if NANOPRINTF_HAVE_GCC_WARNING_PRAGMAS
   #pragma GCC diagnostic push
   #pragma GCC diagnostic ignored "-Wc++98-compat-pedantic"
   #pragma GCC diagnostic ignored "-Wold-style-cast"

--- a/paland.cc
+++ b/paland.cc
@@ -29,8 +29,6 @@
 // Rewritten for nanoprintf by Charles Nicholson (charles.nicholson@gmail.com)
 // A derivative work of Paland's original, so released under the MIT License.
 
-#include "../doctest.h"
-
 #include <string.h>
 #include <math.h>
 #include <limits>
@@ -46,8 +44,18 @@
   #pragma GCC diagnostic push
   #if NANOPRINTF_CLANG
     #pragma GCC diagnostic ignored "-Wc++98-compat-pedantic"
+    #ifndef __APPLE__
+      #pragma GCC diagnostic ignored "-Wreserved-identifier"
+    #endif
+  #endif
+#endif
+
+#include "../doctest.h"
+
+#if NANOPRINTF_HAVE_GCC_WARNING_PRAGMAS
+  #pragma GCC diagnostic push
+  #if NANOPRINTF_CLANG
     #pragma GCC diagnostic ignored "-Wformat-pedantic"
-    #pragma GCC diagnostic ignored "-Wreserved-identifier"
   #endif
   #pragma GCC diagnostic ignored "-Wold-style-cast"
   #pragma GCC diagnostic ignored "-Wpadded"

--- a/paland.cc
+++ b/paland.cc
@@ -41,7 +41,6 @@
 #include <math.h>
 #include <limits>
 #include <string>
-#include <iostream>
 #include <sstream>
 
 // The configuration flags are injected by CMakeLists.txt in the npf project.
@@ -57,6 +56,7 @@
   #endif
 #endif
 
+#define DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS
 #include "../doctest.h"
 
 #if NANOPRINTF_HAVE_GCC_WARNING_PRAGMAS


### PR DESCRIPTION
- have_gcc_warning_pragmas
- clang
- reserved identifier
- copy the unit test header crap to paland
- 4514 msvc
- shut up more warnings
- more warnings
- crazy warnings
- remove iostream, fixed by doctest upgrade
